### PR TITLE
password.py : using errno instead of strerror in _get_lock exception

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -4,6 +4,7 @@
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import annotations
+import errno
 
 DOCUMENTATION = """
     name: password
@@ -276,7 +277,7 @@ def _get_lock(b_path):
             os.close(fd)
             first_process = True
         except OSError as e:
-            if e.strerror != 'File exists':
+            if e.errno != errno.EEXIST:
                 raise
 
     counter = 0


### PR DESCRIPTION
##### SUMMARY

`_get_lock` function is using `strerror` in exception. `strerror` is a localized string so value depends of user language ('File exists' in english became 'Le fichier existe' in french).  `errno` is the best way, as used in all ansible code.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

