### PR TITLE
Update password.py : use errno instead of strerror in _get_lock excep…

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -4,7 +4,6 @@
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import annotations
-import errno
 
 DOCUMENTATION = """
     name: password
@@ -131,6 +130,7 @@ import os
 import string
 import time
 import hashlib
+import errno
 
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text


### PR DESCRIPTION
##### SUMMARY

`_get_lock` function is using `strerror` in exception. `strerror` is a localized string so it depends of user language (ie: 'File exists' with LANG=C is 'Le fichier existe' with LANG=fr_FR). `errno` is used in all ansible code and the best way to test error type.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

